### PR TITLE
fix: fix locals merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function processNodeContentWithPosthtml(node, options) {
  */
 function parseLocals(optionLocals, attributeLocals) {
   try {
-    const locals = merge(optionLocals, JSON.parse(attributeLocals));
+    const locals = merge({...optionLocals}, JSON.parse(attributeLocals));
 
     return expressions({locals});
   } catch {


### PR DESCRIPTION
It prevents the local variable to keep data from longer arrays that was loaded before.